### PR TITLE
fix: Reduce max burnin temporarily for the duration of this build

### DIFF
--- a/src/views/DeviceInspector/OverviewTab.js
+++ b/src/views/DeviceInspector/OverviewTab.js
@@ -17,7 +17,7 @@ const TimeToBurnin = {
 			return m("p.is-size-4", "Burn-in not started");
 
 		// 6 hours in seconds. Taken from the user settings used to store this value
-		const maxBurnin = 21600;
+		const maxBurnin = 1800;
 
 		const numReboots = 3;
 		const burninStageTime = maxBurnin / numReboots;

--- a/src/views/DeviceInspector/OverviewTab.js
+++ b/src/views/DeviceInspector/OverviewTab.js
@@ -16,7 +16,7 @@ const TimeToBurnin = {
 		if (deviceSettings().firmware !== "current")
 			return m("p.is-size-4", "Burn-in not started");
 
-		// 6 hours in seconds. Taken from the user settings used to store this value
+		// 30 minutes in seconds. Taken from the user settings used to store this value
 		const maxBurnin = 1800;
 
 		const numReboots = 3;


### PR DESCRIPTION
Our current integrator is taking on certain burn-in tasks, so we are reducing our own time drastically. This is a temporary measure -- ideally this value would be derived from a per-workspace setting, but we don't have that facility yet.