### PR TITLE
refactor dispatcher

### DIFF
--- a/src/models/User.js
+++ b/src/models/User.js
@@ -6,7 +6,8 @@ import stream from "mithril/stream";
 export default () => {
 	const r = new Request();
 	return {
-		loggedIn: stream(false),
+		loggedIn: () => (r.getToken() ? true : false),
+
 		login(email, pass) {
 			return r
 				.request({
@@ -24,7 +25,6 @@ export default () => {
 
 		refreshToken() {
 			return r.refreshToken().then(result => {
-				this.loggedIn(true);
 				return Promise.resolve(result);
 			});
 		},
@@ -35,11 +35,7 @@ export default () => {
 					method: "POST",
 					url: "/logout"
 				})
-				.then(result => {
-					r.clearToken();
-					this.loggedIn(false);
-					return Promise.resolve(true);
-				});
+				.then(r.clearToken());
 		},
 
 		updatePassword(newPassword) {
@@ -49,10 +45,7 @@ export default () => {
 					url: "/user/me/password",
 					data: { password: newPassword }
 				})
-				.then(() => {
-					this.loggedIn(false);
-					return Promise.resolve(true);
-				});
+				.then(r.clearToken());
 		}
 	};
 };

--- a/src/models/Workspace.js
+++ b/src/models/Workspace.js
@@ -26,15 +26,20 @@ export default id => {
 	const findWorkspaceById = id => workspaces().find(w => w.id === id);
 	const findWorkspaceByName = name => workspaces().find(w => w.name === name);
 
-	const loadCurrentWorkspace = () =>
+    // TODO: I'm not sure this is really the right logic we should be using here
+    // seems that we should just throw an error if we can't find the workspace in
+    // question or return null or something
+	const loadCurrentWorkspace = id =>
 		loadAllWorkspaces().then(() => {
-			let found = findWorkspaceById(id);
+			let found;
+			if (id) found = findWorkspaceById(id);
 			if (!found)
 				found = findWorkspaceById(
 					localStorage.getItem("currentWorkspace")
 				);
 			if (!found) found = findWorkspaceByName("GLOBAL");
 			if (!found) found = workspaces()[0];
+            if (!found) return Promise.reject(id);
 			return currentWorkspace(found);
 		});
 

--- a/src/util/Request.js
+++ b/src/util/Request.js
@@ -19,7 +19,6 @@ export default () => {
 		requestWithToken(args) {
 			const token = this.getToken();
 			if (!token) {
-                console.log("False token: " + token);
 				return Promise.reject(false);
 			}
 			// TODO add support for headers being passed in

--- a/src/util/Request.js
+++ b/src/util/Request.js
@@ -19,6 +19,7 @@ export default () => {
 		requestWithToken(args) {
 			const token = this.getToken();
 			if (!token) {
+                console.log("False token: " + token);
 				return Promise.reject(false);
 			}
 			// TODO add support for headers being passed in

--- a/src/views/Login.js
+++ b/src/views/Login.js
@@ -77,18 +77,16 @@ export default () => {
 														emailAddress,
 														password
 													)
-													.then(
-														() => {
-															badLoginAttempt = false;
-															m.route.set(
-																m.route.get()
-															);
-														},
-														() => {
-															badLoginAttempt = true;
-															password = "";
-														}
-													)
+													.then(() => {
+														badLoginAttempt = false;
+                                                        console.log(user.loggedIn());
+                                                        console.log("redirecting to /");
+														m.route.set("/");
+													})
+													.catch(() => {
+														badLoginAttempt = true;
+														password = "";
+													})
 													.then(() => {
 														e.target.classList.remove(
 															"is-loading"

--- a/src/views/Login.js
+++ b/src/views/Login.js
@@ -79,8 +79,6 @@ export default () => {
 													)
 													.then(() => {
 														badLoginAttempt = false;
-                                                        console.log(user.loggedIn());
-                                                        console.log("redirecting to /");
 														m.route.set("/");
 													})
 													.catch(() => {


### PR DESCRIPTION
Writing tests I discovered that the dispatcher is nearly untestable. So I hoisted out the heavy lifting  logic and put it into the Workspaces object.

This also updates the login workflow to use the slightly more intuitive `/login` URL and cleans up the loggedIn/loggedOut logic.