### PR TITLE
fix workspace switching

### DIFF
--- a/src/models/Workspace.js
+++ b/src/models/Workspace.js
@@ -26,10 +26,10 @@ export default id => {
 	const findWorkspaceById = id => workspaces().find(w => w.id === id);
 	const findWorkspaceByName = name => workspaces().find(w => w.name === name);
 
-    // TODO: I'm not sure this is really the right logic we should be using here
-    // seems that we should just throw an error if we can't find the workspace in
-    // question or return null or something
-	const loadCurrentWorkspace = id =>
+	// TODO: I'm not sure this is really the right logic we should be using here
+	// seems that we should just throw an error if we can't find the workspace in
+	// question or return null or something
+	const loadCurrentWorkspace = () =>
 		loadAllWorkspaces().then(() => {
 			let found;
 			if (id) found = findWorkspaceById(id);
@@ -39,7 +39,7 @@ export default id => {
 				);
 			if (!found) found = findWorkspaceByName("GLOBAL");
 			if (!found) found = workspaces()[0];
-            if (!found) return Promise.reject(id);
+			if (!found) return Promise.reject(id);
 			return currentWorkspace(found);
 		});
 


### PR DESCRIPTION
This fixes #62.

Turns out that when you shadow the `id` parameter but don't provide a new
value in a method call you don't actually end up doing anything.

This commit fixes things by removing the shadowed id so that the `loadCurrentWorkspace()`
method does what it says on the tin.