### PR TITLE
Prepend conch-api URL to XHR request URLs using global constant

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -180,4 +180,13 @@ module.exports = {
 
   // Whether to use watchman for file crawling
   // watchman: true,
+
+  // Global constants, which should mirror the global constants in webpack.common.js
+  globals: {
+    CONCH: {
+      GLOBALS: {
+        apiUrl: JSON.stringify("http://localhost:5001"),
+      }
+    }
+  }
 };

--- a/src/util/Request.js
+++ b/src/util/Request.js
@@ -14,6 +14,7 @@ export default () => {
 		},
 		request(args) {
 			args.withCredentials = true;
+			if (args.url) args.url = CONCH.GLOBALS.apiUrl + args.url;
 			return m.request(args);
 		},
 		requestWithToken(args) {

--- a/webpack.common.js
+++ b/webpack.common.js
@@ -65,6 +65,14 @@ module.exports = {
 			template: 'src/index.html',
 			favicon: './src/styles/images/favicon.ico'
 		}),
+		// Global constants, which should mirror the global constants in jest.config.js
+		new webpack.DefinePlugin({
+			CONCH: {
+				GLOBALS: {
+					apiUrl: JSON.stringify("http://localhost:5001"),
+				}
+			},
+		}),
 	],
 };
 


### PR DESCRIPTION
These changes implement the ability to add global constants through the common webpack config. These globals are then mirrored in the Jest config so that tests run with the same global constant values.