### PR TITLE
move the 401 checking into the Request object

### DIFF
--- a/src/models/User.js
+++ b/src/models/User.js
@@ -30,8 +30,9 @@ export default () => {
 		},
 
 		logout() {
+            //TODO As of this moment the server doesn't require authentication for `/logout` but it probably should.
 			return r
-				.request({
+				.requestWithToken({
 					method: "POST",
 					url: "/logout"
 				})

--- a/src/models/Workspace.js
+++ b/src/models/Workspace.js
@@ -20,13 +20,7 @@ export default id => {
 				method: "GET",
 				url: "/workspace"
 			})
-			.then(workspaces)
-			.catch(response => {
-				// If 401 (Unauthorized) is returned, clear the stale token.
-				if (response.error === 'unauthorized') {
-					r.clearToken();
-				}
-			});
+			.then(workspaces);
 	};
 
 	const findWorkspaceById = id => workspaces().find(w => w.id === id);

--- a/src/util/Request.js
+++ b/src/util/Request.js
@@ -7,7 +7,7 @@ export default () => {
 		},
 		setToken(token) {
 			localStorage.setItem("token", token);
-            return Promise.resolve(true);
+			return Promise.resolve(true);
 		},
 		clearToken() {
 			return localStorage.removeItem("token");
@@ -25,7 +25,10 @@ export default () => {
 			args.headers = {
 				Authorization: "Bearer " + token
 			};
-			return this.request(args);
+			return this.request(args).catch(e => {
+				this.clearToken();
+				Promise.reject(e);
+			});
 		},
 		refreshToken() {
 			return this.requestWithToken({
@@ -34,9 +37,9 @@ export default () => {
 			}).then(result => {
 				if (result && result.jwt_token) {
 					this.setToken(result.jwt_token);
-                    return Promise.resolve(result.jwt_token);
+					return Promise.resolve(result.jwt_token);
 				}
-                this.clearToken();
+				this.clearToken();
 				return Promise.reject(false);
 			});
 		}


### PR DESCRIPTION
PR#71 worked for the endpoints it covered, but it would be nicer to be able to push this logic down a little lower rather than have to put a `catch` at the end of every token chain.

Turns out we just need to propegate through a rejected promise from the initial `catch` in the Request object method `requestWithToken()`.

