### PR TITLE
Current Workspace refactor

### DIFF
--- a/src/dispatch.js
+++ b/src/dispatch.js
@@ -41,6 +41,7 @@ import Workspace from "models/Workspace";
 /// IIFE to prevent escaping scope
 const dispatch = (() => {
 	const user = new User();
+	const currentWorkspace = stream();
 
 	function dispatch(root, routes) {
 		const table = Object.keys(routes).reduce((accTable, route) => {
@@ -54,27 +55,27 @@ const dispatch = (() => {
 					if (!user.loggedIn()) return m.route.set("/login");
 					return Workspace.loadAllWorkspaces()
 						.then(() => new Workspace(args.wid))
-						.then(({currentWorkspace, workspaces}) =>
+						.then(currentWorkspace)
+						.then(() =>
 							m(view, {
 								currentWorkspace,
-								workspaces,
+								workspaces: Workspace.workspaces,
 								user
 							})
 						)
 						.catch(WorkspaceNotFound(args.wid));
 				},
-				render({ attrs: { wid } }) {
-					const ws = new Workspace(wid);
+				render() {
 					return m(
 						layout,
 						{
-							currentWorkspace: ws.currentWorkspace,
-							workspaces: ws.workspaces,
+							currentWorkspace,
+							workspaces: Workspace.workspaces,
 							user
 						},
 						m(view, {
-							currentWorkspace: ws.currentWorkspace,
-							workspaces: ws.workspaces,
+							currentWorkspace,
+							workspaces: Workspace.workspaces,
 							user
 						})
 					);

--- a/src/dispatch.js
+++ b/src/dispatch.js
@@ -54,10 +54,10 @@ const dispatch = (() => {
 					if (!user.loggedIn()) return m.route.set("/login");
 					return Workspace.loadAllWorkspaces()
 						.then(() => new Workspace(args.wid))
-						.then(ws =>
+						.then(({currentWorkspace, workspaces}) =>
 							m(view, {
-								currentWorkspace: ws.currentWorkspace,
-								workspaces: ws.workspaces,
+								currentWorkspace,
+								workspaces,
 								user
 							})
 						)
@@ -90,7 +90,7 @@ const dispatch = (() => {
 				if (!user.loggedIn()) return m.route.set("/login");
 
 				return Workspace.loadAllWorkspaces()
-					.then(ws => Workspace.findCurrentWorkspace(ws, ""))
+					.then(Workspace.findBestWorkspace)
 					.then(w => m.route.set(`/${w.id}/status`))
 					.catch(m.route.set("/login"));
 			}

--- a/src/models/User.js
+++ b/src/models/User.js
@@ -6,7 +6,7 @@ import stream from "mithril/stream";
 export default () => {
 	const r = new Request();
 	return {
-		loggedIn: () => (r.getToken() ? true : false),
+		loggedIn: () => !!r.getToken(),
 
 		login(email, pass) {
 			return r
@@ -30,7 +30,7 @@ export default () => {
 		},
 
 		logout() {
-            //TODO As of this moment the server doesn't require authentication for `/logout` but it probably should.
+			//TODO As of this moment the server doesn't require authentication for `/logout` but it probably should.
 			return r
 				.requestWithToken({
 					method: "POST",

--- a/src/models/Workspace.js
+++ b/src/models/Workspace.js
@@ -5,68 +5,9 @@ import stream from "mithril/stream";
 import moment from "moment";
 
 const r = new Request();
-const workspaces = stream();
+const workspaces = stream([]);
 
-const Workspace = id => {
-	if (!id) throw "ID required";
-
-	const currentWorkspace = workspaces.map(ws => {
-		if (!ws) return;
-		// check for the passed in workspace ID
-		if (id) {
-			let found = ws.find(w => w.id === id);
-			if (found) return found;
-		}
-		return Workspace.findBestWorkspace(ws);
-	});
-
-	currentWorkspace.map(ws => {
-		if (ws) localStorage.setItem("currentWorkspace", ws.id);
-	});
-
-	const getDevices = () =>
-		r.requestWithToken({
-			method: "GET",
-			url: `/workspace/${id}/device`
-		});
-
-	return {
-		currentWorkspace,
-		workspaces,
-		getAll: () => Workspace.loadAllWorkspaces(),
-		getDevices,
-		getAllRacks: () =>
-			r.requestWithToken({
-				method: "GET",
-				url: `/workspace/${id}/rack`
-			}),
-
-		// TODO: replace this with a method in `model/Racks.js` that calls the `/rack` endpoint instead
-		getRackById: rackId =>
-			r
-				.requestWithToken({
-					method: "GET",
-					url: `/workspace/${id}/rack/${rackId}`
-				})
-				.then(res => {
-					res.slots = res.slots.reduce((obj, curr) => {
-						obj[curr.rack_unit_start] = curr;
-						return obj;
-					}, {});
-					return Promise.resolve(res);
-				}),
-
-		// TODO: replace this with a method in `model/Racks.js` that calls the `/rack` endpoint instead
-		setRackLayout: (rackId, layout) =>
-			r.requestWithToken({
-				method: "POST",
-				url: `/workspace/${id}/rack/${rackId}/layout`,
-				data: layout
-			})
-	};
-};
-
-Workspace.findBestWorkspace = ws => {
+const bestFallback = workspaces.map(ws => {
 	// check for a stored ID
 	const storedId = localStorage.getItem("currentWorkspace");
 
@@ -81,6 +22,69 @@ Workspace.findBestWorkspace = ws => {
 
 	// just return the first one
 	return ws[0];
+});
+
+const Workspace = id => {
+	if (!id) throw "ID required";
+
+	const currentWorkspace =
+		workspaces().find(w => w.id === id) || bestFallback();
+
+	if (currentWorkspace)
+		localStorage.setItem("currentWorkspace", currentWorkspace.id);
+
+	const getDevices = () =>
+		r.requestWithToken({
+			method: "GET",
+			url: `/workspace/${id}/device`
+		});
+
+	const getAllRacks = () =>
+		r.requestWithToken({
+			method: "GET",
+			url: `/workspace/${id}/rack`
+		});
+
+	const getAll = () => Workspace.loadAllWorkspaces();
+
+	// TODO: replace this with a method in `model/Racks.js` that calls the `/rack` endpoint instead
+	const getRackById = rackId =>
+		r
+			.requestWithToken({
+				method: "GET",
+				url: `/workspace/${id}/rack/${rackId}`
+			})
+			.then(res => {
+				res.slots = res.slots.reduce((obj, curr) => {
+					obj[curr.rack_unit_start] = curr;
+					return obj;
+				}, {});
+				return Promise.resolve(res);
+			});
+
+	// TODO: replace this with a method in `model/Racks.js` that calls the `/rack` endpoint instead
+	const setRackLayout = (rackId, layout) =>
+		r.requestWithToken({
+			method: "POST",
+			url: `/workspace/${id}/rack/${rackId}/layout`,
+			data: layout
+		});
+
+	return Object.assign(
+		{
+			workspaces,
+			getAllRacks,
+			getDevices,
+			getAll,
+			getRackById,
+			setRackLayout
+		},
+		currentWorkspace
+	);
+};
+
+Workspace.findBestWorkspace = () => {
+	bestFallback();
 };
 
 Workspace.loadAllWorkspaces = () => {
@@ -91,5 +95,7 @@ Workspace.loadAllWorkspaces = () => {
 		})
 		.then(workspaces);
 };
+
+Workspace.workspaces = workspaces;
 
 export { Workspace as default };

--- a/src/util/Request.js
+++ b/src/util/Request.js
@@ -3,14 +3,14 @@ import m from "mithril";
 export default () => {
 	return {
 		getToken() {
-			return localStorage.getItem("token");
+			return sessionStorage.getItem("token");
 		},
 		setToken(token) {
-			localStorage.setItem("token", token);
+			sessionStorage.setItem("token", token);
 			return Promise.resolve(true);
 		},
 		clearToken() {
-			return localStorage.removeItem("token");
+			return sessionStorage.removeItem("token");
 		},
 		request(args) {
 			args.withCredentials = true;

--- a/src/util/Request.js
+++ b/src/util/Request.js
@@ -26,7 +26,7 @@ export default () => {
 				Authorization: "Bearer " + token
 			};
 			return this.request(args).catch(e => {
-				this.clearToken();
+				if (e.code === 401) this.clearToken();
 				Promise.reject(e);
 			});
 		},

--- a/src/views/DatacenterBrowser/EditLayoutModal.js
+++ b/src/views/DatacenterBrowser/EditLayoutModal.js
@@ -33,7 +33,7 @@ const SaveEditButton = {
 					duplicateSerials(duplicates);
 					if (Object.keys(duplicateSerials()).length === 0) {
 						e.target.classList.add("is-loading");
-						const workspace = new Workspace(currentWorkspace().id);
+						const workspace = currentWorkspace();
 						workspace
 							.setRackLayout(activeRack().id, layout)
 							.then(res => {

--- a/src/views/DatacenterBrowser/index.js
+++ b/src/views/DatacenterBrowser/index.js
@@ -71,7 +71,7 @@ export default () => {
 	return {
 		oninit({ attrs: { currentWorkspace } }) {
 			// side-effect: load the rack whenever activeRack updates
-			const workspace = new Workspace(currentWorkspace().id);
+			const workspace = currentWorkspace();
 			activeRack.map(rack => {
 				rackLoading(true);
 				workspace.getRackById(rack.id).then(res => {

--- a/src/views/DeviceInspector/Tabs.js
+++ b/src/views/DeviceInspector/Tabs.js
@@ -13,7 +13,8 @@ export default () => {
 
 			activeTab(showTab);
 
-			activeTab.map(tab => {
+/*
+            activeTab.map(tab => {
 				let route = m.route.get();
 				let [mainRoute, queryS] = route.split("?");
 				let queryParams;
@@ -23,6 +24,7 @@ export default () => {
 				let newQueryS = m.buildQueryString(queryParams);
 				m.route.set(`${mainRoute}?${newQueryS}`);
 			});
+*/
 		},
 		view: ({
 			attrs: { tabs, activeDevice, activeDeviceId, deviceSettings }

--- a/src/views/Devices/DevicesPanel.js
+++ b/src/views/Devices/DevicesPanel.js
@@ -9,6 +9,15 @@ import {
 	deviceToProgress
 } from "views/DatacenterBrowser/Progress";
 
+const routeFor = deviceId => {
+	const route = m.route.get();
+	const routePrefix = route.substring(0, route.indexOf("/device"));
+	let [_, queryS] = route.split("?");
+	queryS ? (queryS = `?${queryS}`) : (queryS = "");
+
+	return `${routePrefix}/device/${deviceId}${queryS}`;
+};
+
 export default () => {
 	const deviceSearchText = stream("");
 	const deviceSearchTextLC = deviceSearchText.map(t => t.toLowerCase());
@@ -158,7 +167,7 @@ export default () => {
 								"a.panel-block",
 								{
 									onclick: e => {
-										activeDeviceId(device.id);
+										m.route.set(routeFor(device.id));
 									},
 									class:
 										activeDeviceId() === device.id &&

--- a/src/views/Devices/DevicesPanel.js
+++ b/src/views/Devices/DevicesPanel.js
@@ -51,12 +51,6 @@ export default () => {
 
 	let filteredDevices;
 
-	//const selectedProgress = stream("all");
-	//const rackProgressFilter = rack =>
-	//selectedProgress() === "all" ||
-	//selectedProgress() === rackToProgress(rack);
-	//let availableRackProgress;
-
 	return {
 		oninit: ({ attrs: { workspaceDevices, hardwareProductLookup } }) => {
 			availableDeviceProgress = workspaceDevices.map(devices =>
@@ -89,6 +83,7 @@ export default () => {
 				selectedProgress("all");
 				deviceSearchText("");
 			});
+            workspaceDevices.map(() => console.log("workspaceDevices updated"));
 			filteredDevices = stream.combine(
 				(devices, filter) => devices().filter(filter()),
 				[workspaceDevices, deviceFilter]

--- a/src/views/Devices/DevicesPanel.js
+++ b/src/views/Devices/DevicesPanel.js
@@ -83,7 +83,6 @@ export default () => {
 				selectedProgress("all");
 				deviceSearchText("");
 			});
-            workspaceDevices.map(() => console.log("workspaceDevices updated"));
 			filteredDevices = stream.combine(
 				(devices, filter) => devices().filter(filter()),
 				[workspaceDevices, deviceFilter]

--- a/src/views/Devices/index.js
+++ b/src/views/Devices/index.js
@@ -21,6 +21,7 @@ export default () => {
 
 	return {
 		oninit: ({ attrs: { currentWorkspace } }) => {
+/*
 			activeDeviceId.map(deviceId => {
 				const route = m.route.get();
 				const routePrefix = route.substring(
@@ -32,11 +33,12 @@ export default () => {
 
 				if (deviceId)
 					m.route.set(`${routePrefix}/device/${deviceId}${queryS}`);
-				else m.route.set(`${routePrefix}/device`);
+		//		else m.route.set(`${routePrefix}/device`);
 			});
-
-			m.route.param("deviceId") &&
+*/
+			m.route.param("deviceId") !== null &&
 				activeDeviceId(m.route.param("deviceId"));
+
 			hardwareProducts.get().then(hardwareProducts => {
 				hardwareProductLookup = keyBy(hardwareProducts, "id");
 			});

--- a/src/views/Devices/index.js
+++ b/src/views/Devices/index.js
@@ -32,10 +32,8 @@ export default () => {
 				.get()
 				.then(hardwareProducts => keyBy(hardwareProducts, "id"))
 				.then(hardwareProductLookup);
-            console.log(JSON.stringify(currentWorkspace));
-			currentWorkspace.map( ws  => {
-				console.log(JSON.stringify(ws));
-				const workspace = new Workspace(ws.id);
+
+			currentWorkspace.map(workspace => {
 				workspace
 					.getDevices()
 					.then(devices => devices.sort((a, b) => a.id - b.id))

--- a/src/views/Devices/index.js
+++ b/src/views/Devices/index.js
@@ -13,56 +13,33 @@ import DeviceInspector from "views/DeviceInspector";
 import HardwareProducts from "models/HardwareProduct";
 import Workspace from "models/Workspace";
 
+let workspaceDevices = stream();
+
 export default () => {
-	let workspaceDevices = stream();
-	let hardwareProductLookup;
-	const activeDeviceId = stream();
+	const hardwareProductLookup = stream();
 	const hardwareProducts = new HardwareProducts();
+
+	const activeDeviceId = workspaceDevices.map(devices => {
+		const activeDevice = devices.find(
+			d => d && d.id === m.route.param("deviceId")
+		);
+		return activeDevice && activeDevice.id;
+	});
 
 	return {
 		oninit: ({ attrs: { currentWorkspace } }) => {
-/*
-			activeDeviceId.map(deviceId => {
-				const route = m.route.get();
-				const routePrefix = route.substring(
-					0,
-					route.indexOf("/device")
-				);
-				let [_, queryS] = route.split("?");
-				queryS ? (queryS = `?${queryS}`) : (queryS = "");
-
-				if (deviceId)
-					m.route.set(`${routePrefix}/device/${deviceId}${queryS}`);
-		//		else m.route.set(`${routePrefix}/device`);
-			});
-*/
-			m.route.param("deviceId") !== null &&
-				activeDeviceId(m.route.param("deviceId"));
-
-			hardwareProducts.get().then(hardwareProducts => {
-				hardwareProductLookup = keyBy(hardwareProducts, "id");
-			});
-
-			currentWorkspace.map(({ id }) => {
-				// drop the previous stream
-				workspaceDevices = stream();
-				const workspace = new Workspace(id);
-				workspace.getDevices().then(devices => {
-					let foundActiveDevice = false;
-					// sort and attempt to find the currently active device ID
-					devices.sort((a, b) => {
-						if (
-							activeDeviceId() != null &&
-							(activeDeviceId() === a.id ||
-								activeDeviceId() === b.id)
-						)
-							foundActiveDevice = true;
-						// negative == a, 0, postiive == b
-						return a.id - b.id;
-					});
-					workspaceDevices(devices);
-					if (!foundActiveDevice) activeDeviceId(null);
-				});
+			hardwareProducts
+				.get()
+				.then(hardwareProducts => keyBy(hardwareProducts, "id"))
+				.then(hardwareProductLookup);
+            console.log(JSON.stringify(currentWorkspace));
+			currentWorkspace.map( ws  => {
+				console.log(JSON.stringify(ws));
+				const workspace = new Workspace(ws.id);
+				workspace
+					.getDevices()
+					.then(devices => devices.sort((a, b) => a.id - b.id))
+					.then(workspaceDevices);
 			});
 		},
 		view: ({ attrs: { currentWorkspace } }) => {
@@ -80,7 +57,7 @@ export default () => {
 							m(
 								"article.tile.is-child",
 								workspaceDevices() == null ||
-								hardwareProductLookup == null
+								hardwareProductLookup() == null
 									? m("section.section", m(Spinner))
 									: m(
 											".columns",
@@ -88,7 +65,7 @@ export default () => {
 												".column.is-4",
 												m(DevicesPanel, {
 													workspaceDevices,
-													hardwareProductLookup,
+													hardwareProductLookup: hardwareProductLookup(),
 													activeDeviceId
 												})
 											),

--- a/src/views/Status/index.js
+++ b/src/views/Status/index.js
@@ -112,18 +112,20 @@ export default () => {
 
 	return {
 		oninit({ attrs: { currentWorkspace } }) {
-			currentWorkspace.map(({ id }) => {
+			currentWorkspace.map(workspace => {
 				devices(null);
-				const workspace = new Workspace(id);
-				workspace.getDevices().then(res => {
-					devices(res.sort((a, b) => a.id - b.id));
-					const newProgress = { pass: 0, total: 0 };
-					devices().forEach(device => {
-						if (device.health === "PASS") newProgress.pass++;
-						newProgress.total++;
+				workspace
+					.getDevices()
+					.then(res => res.sort((a, b) => a.id - b.id))
+					.then(devices)
+					.then(res => {
+						const newProgress = { pass: 0, total: 0 };
+						res.forEach(device => {
+							if (device.health === "PASS") newProgress.pass++;
+							newProgress.total++;
+						});
+						progress(newProgress);
 					});
-					progress(newProgress);
-				});
 
 				rackCount = null;
 				rackRooms = null;


### PR DESCRIPTION
This refactors the way we identify and pass through the `currentWorkspace`. Rather than passing down a data object we fetch and pass down a `Workspace` instance that has the data folded into it.

This should enable some clean up some of the way we handle the workspace logic inside the controllers going forward.