### PR TITLE
add explicit code to get the HTTP Response on error

### DIFF
--- a/src/util/Request.js
+++ b/src/util/Request.js
@@ -25,9 +25,21 @@ export default () => {
 			args.headers = {
 				Authorization: "Bearer " + token
 			};
+			args.extract = xhr => {
+				const success =
+					(xhr.status >= 200 && xhr.status < 300) ||
+					xhr.status === 304;
+				if (success) {
+					return JSON.parse(xhr.responseText);
+				} else {
+					const error = new Error(xhr.responseText);
+					error.code = xhr.status;
+					return error;
+				}
+			};
 			return this.request(args).catch(e => {
-				this.clearToken();
-				Promise.reject(e);
+				if (e.code === 401) this.clearToken();
+				return Promise.reject(e);
 			});
 		},
 		refreshToken() {


### PR DESCRIPTION
The version of Mithril we're using (1.1.3) doesn't properly pass through
the `xhr.status` on error so when we try to handle error conditions we
can't tell if it's a 401 or not. This caused us to log out on every
error, including 404s.

This adds some logic to our own request handler from a more recent
version of Mithril to copy over the HTTP Status code from the XHR
request so we can tell what it was and dispatch accordingly.