### PR TITLE
Adds validation version number and active/inactive status to device inspector validations tab

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,6 +6,7 @@
   "dependencies": {
     "babel-cli": "^6.26.0",
     "bulma": "^0.7.1",
+    "bulma-tooltip": "^2.0.2",
     "bulmaswatch": "^0.6.2",
     "d3": "^4.10.2",
     "d3-relationshipgraph": "^3.0.2",

--- a/src/styles/main.scss
+++ b/src/styles/main.scss
@@ -1,6 +1,7 @@
 @import "d3.relationshipgraph.min.css";
 
 @import "bulmaswatch/superhero/bulmaswatch.scss";
+@import "bulma-tooltip/dist/css/bulma-tooltip.sass";
 
 // Extend Bulma's panel-tabs class to wrap items
 .panel-tabs {

--- a/src/views/DeviceInspector/ValidationTab.js
+++ b/src/views/DeviceInspector/ValidationTab.js
@@ -54,7 +54,25 @@ const ValidationRow = () => {
 					"td",
 					validation.description ||
 						m("span.has-text-grey", "No Description")
-				)
+				),
+				m(
+					"td.has-text-centered",
+					validation.version
+				),
+				m(
+					"td",
+					validation.deactivated == null
+						? m(
+							"span.icon.is-medium.has-text-success.tooltip.is-tooltip-left.is-tooltip-success",
+							{ "data-tooltip": "Active Validation" },
+							m("i.fas.fa-lg.fa-check-circle")
+						  )
+						: m(
+							"span.icon.is-medium.has-text-warning.tooltip.is-tooltip-left.is-tooltip-warning",
+							{ "data-tooltip": "Inactive Validation" },
+							m("i.fas.fa-lg.fa-exclamation-triangle")
+						  )
+				),
 			),
 			revealDetails &&
 				m(
@@ -113,7 +131,9 @@ const ValidationTab = () => {
 		m("th", ""),
 		m("th", "Status"),
 		m("th", "Name"),
-		m("th", "Description")
+		m("th", "Description"),
+		m("th", "Version"),
+		m("th", "")
 	];
 	const validationStates = stream();
 	const validations = stream();

--- a/yarn.lock
+++ b/yarn.lock
@@ -1510,6 +1510,11 @@ builtin-status-codes@^3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/builtin-status-codes/-/builtin-status-codes-3.0.0.tgz#85982878e21b98e1c66425e03d0174788f569ee8"
 
+bulma-tooltip@^2.0.2:
+  version "2.0.2"
+  resolved "https://registry.yarnpkg.com/bulma-tooltip/-/bulma-tooltip-2.0.2.tgz#cf0bf5ad2dc75492cbcbd4816e1a005314dc90ac"
+  integrity sha512-xsqWeWV7tsUn3uH04SqJeP7/CyC1RaDVIyVzr4/sIO3friIIOi7L6jc5g7qUwDxuBQl72yH/yRPuefpXoQ4hWg==
+
 bulma@^0.7.1:
   version "0.7.1"
   resolved "https://registry.yarnpkg.com/bulma/-/bulma-0.7.1.tgz#73c2e3b2930c90cc272029cbd19918b493fca486"


### PR DESCRIPTION
(Please see screenshots below)

Adds two new columns to the Validations tab table:
1. The version of the validation
2. The `active/inactive` status of the validation. Active status is denoted by a green circle checkmark icon, which displays a tooltip reading `Active Validation` when hovered over. Inactive (deactivated) status is denoted by a yellow triangle exclamation mark icon, which displays a tooltip reading `Inactive Validation` when hovered over.

<img width="773" alt="screen shot 2019-03-01 at 1 24 58 pm" src="https://user-images.githubusercontent.com/2080476/53668233-247c6000-3c28-11e9-8e84-da4740e9cf2a.png">
<img width="179" alt="screen shot 2019-03-01 at 1 26 36 pm" src="https://user-images.githubusercontent.com/2080476/53668237-29d9aa80-3c28-11e9-9934-1da8f4f2e1e5.png">
<img width="212" alt="screen shot 2019-03-01 at 1 27 22 pm" src="https://user-images.githubusercontent.com/2080476/53668242-2cd49b00-3c28-11e9-98f7-1151f7e57c74.png">
