### PR TITLE
Redirect user to update password when password is reset

### DIFF
--- a/src/models/User.js
+++ b/src/models/User.js
@@ -6,6 +6,17 @@ import stream from "mithril/stream";
 export default () => {
 	const r = new Request();
 	return {
+		isForcePasswordChange() {
+			return r
+				.request({
+					method: "GET",
+					url: "/user/me",
+				})
+				.then(response => {
+					return Promise.resolve(response.force_password_change);
+				});
+		},
+
 		loggedIn: () => !!r.getToken(),
 
 		login(email, pass) {

--- a/src/views/Login.js
+++ b/src/views/Login.js
@@ -1,6 +1,7 @@
 import m from "mithril";
 
 import User from "models/User";
+import Workspace from "models/Workspace";
 
 export default () => {
 	let badLoginAttempt = false;
@@ -79,7 +80,18 @@ export default () => {
 													)
 													.then(() => {
 														badLoginAttempt = false;
-														m.route.set("/");
+														user.isForcePasswordChange()
+															.then(isForcePasswordChange => {
+																if (isForcePasswordChange) {
+																	Workspace.loadAllWorkspaces()
+																		.then(Workspace.findBestWorkspace)
+																		.then(w => m.route.set(`/${w.id}/user`, {
+																			forcePasswordUpdate: true
+																		}));
+																} else {
+																	m.route.set("/");
+																}
+															});
 													})
 													.catch(() => {
 														badLoginAttempt = true;

--- a/src/views/User/index.js
+++ b/src/views/User/index.js
@@ -1,6 +1,8 @@
 import m from "mithril";
 import { ViewTitleHero } from "views/component/";
 
+let showModal = false;
+
 const StatusTile = {
 	view: ({ children }) =>
 		m(".tile.is-parent", m("article.tile.is-child.box", children))
@@ -52,13 +54,68 @@ const statusTiles = {
 
 export default () => {
 	return {
+		oninit: () => {
+			showModal = m.route.param("forcePasswordUpdate");
+		},
 		view: ({ attrs: { user } }) => {
 			return [
 				m(ViewTitleHero, {
 					title: "User profile",
 					subtitle: "Update password and profile settings"
 				}),
-				m(statusTiles, { user })
+				m(statusTiles, { user }),
+				showModal &&
+					m(
+						".modal.is-active",
+						m(
+							".modal-background",
+							{
+								onclick(e) {
+									e.preventDefault();
+									showModal = false;
+								}
+							}
+						),
+						m(
+							".modal-card",
+							m(
+								"section.modal-card-body[style=padding:0px;]",
+								m(
+									"article.message.is-danger.is-medium",
+									m(
+										".message-header",
+										m("p", "Password Update Required"),
+										m(
+											"button.delete.is-medium[aria-label=delete]",
+											{
+												onclick(e) {
+													e.preventDefault();
+													showModal = false;
+												}
+											}
+										),
+									),
+									m(
+										".message-body",
+										m(
+											"p[style=margin-bottom:20px;]",
+											"Your password needs to be updated immediately."
+										),
+										m(
+											"a.button.is-danger",
+											{
+												onclick(e) {
+													e.preventDefault();
+													showModal = false;
+												}
+											},
+											"Update Password",
+										),
+									),
+								),
+							),
+						),
+					),
 			];
 		}
 	};


### PR DESCRIPTION
Closes https://github.com/joyent/conch-ui/issues/50

- Immediately redirects user to profile page after successful login
- Displays notification on profile page providing more information about whey they were redirected and what action they need to take

Here's the notification they'll see after being redirected:
<img width="651" alt="Screen Shot 2019-03-26 at 11 05 19 AM" src="https://user-images.githubusercontent.com/2080476/55028068-0b1ac980-4fc4-11e9-95e1-e8963e47eb4a.png">
