### PR TITLE
Update docker test process to hopefully behave better

### DIFF
--- a/docker/test.bash
+++ b/docker/test.bash
@@ -9,8 +9,8 @@ LABEL=$(echo "${LABEL}" | sed 's/\//_/g')
 set -euo pipefail
 IFS=$'\n\t'
 
-PREFIX=${PREFIX} LABEL=${LABEL} docker/builder.bash --file Dockerfile .
-
+PREFIX=${PREFIX} LABEL=${LABEL} docker/builder.bash --file Dockerfile . \
+	&& \
 docker run \
 	--rm \
 	--name ${PREFIX}_${BUILDNUMBER} \

--- a/docker/test.bash
+++ b/docker/test.bash
@@ -15,5 +15,3 @@ docker run \
 	--rm \
 	--name ${PREFIX}_${BUILDNUMBER} \
 	${PREFIX}/conch-ui:${LABEL}
-
-docker rmi ${PREFIX}/conch-ui:${LABEL}


### PR DESCRIPTION
* Image cleanup has been removed and pushed into the build server cleanup processes. Should resolve the build failures we've seen today
* Test will not proceed if the image build failed. Should prevent issues down the road