### PR TITLE
Add flag to ignore engines check

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -22,7 +22,7 @@ format: ## Format Javascript source files with prettier
 	@yarn prettier
 
 node_modules: yarn.lock
-	@yarn install
+	@yarn install --ignore-engines
 	@touch node_modules
 
 dist/index.html: src/**/* config.js webpack.common.js webpack.prod.js


### PR DESCRIPTION
Some dependencies specify a node version for their package. If the current version of node running on the machine doesn't match, `yarn install` will fail, even if the current running version of node is newer than the dependencies specification. Adding `--ignore-engines` allows yarn to skip the engine check.

Here's some documentation and context:
**Documentation:**
https://yarnpkg.com/en/docs/cli/install#toc-yarn-install-ignore-engines
https://docs.npmjs.com/files/package.json#engines

**Context:**
Bug report: https://github.com/yarnpkg/yarn/issues/638 (provides an example of where using the `--ignore-engines` flag is necessary)