### PR TITLE
Allow the GitRevision webpack plugin to use lightweight tags to grab the right version number

### DIFF
--- a/webpack.common.js
+++ b/webpack.common.js
@@ -5,9 +5,7 @@ const HtmlWebpackPlugin = require('html-webpack-plugin');
 const GitRevisionWebpackPlugin = require('git-revision-webpack-plugin');
 const webpack = require('webpack');
 const VueLoaderPlugin = require('vue-loader/lib/plugin');
-const package = require('./package.json');
-
-const gitRevisionPlugin = new GitRevisionWebpackPlugin();
+const gitRevisionPlugin = new GitRevisionWebpackPlugin({ lightweightTags: true });
 
 module.exports = {
 	entry: {


### PR DESCRIPTION
Closes https://github.com/joyent/conch-ui/issues/123.