### PR TITLE
Only overlay errors, not warnings

### DIFF
--- a/vue.config.js
+++ b/vue.config.js
@@ -72,7 +72,6 @@ module.exports = {
         hot: true,
         open: true,
         overlay: {
-            warnings: true,
             errors: true,
         },
         proxy: {


### PR DESCRIPTION
Updates config file to remove screen overlays for warnings, which occur often during development.