### PR TITLE
Password reset login fix

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -1,6 +1,7 @@
 <template>
     <div id="app">
         <SignIn v-if="this.$route.path === '/'" />
+        <PasswordReset v-else-if="this.$route.path === '/password-reset'" />
         <div class="signed-in" v-else>
             <router-view name="sidebar"></router-view>
             <div class="page">
@@ -12,6 +13,7 @@
 </template>
 
 <script>
+import PasswordReset from './views/PasswordReset/PasswordReset.vue';
 import SignIn from './views/SignIn/SignIn.vue';
 import isEmpty from 'lodash/isEmpty';
 import { mapActions, mapGetters, mapState } from 'vuex';
@@ -28,6 +30,7 @@ import { getRackRooms, getWorkspaceRacks } from '@views/shared/utils.js';
 
 export default {
     components: {
+        PasswordReset,
         SignIn,
     },
     methods: {

--- a/src/__tests__/App.test.js
+++ b/src/__tests__/App.test.js
@@ -46,6 +46,14 @@ describe('App.vue', () => {
         });
     });
 
+    describe('PasswordReset', () => {
+        test('should display the PasswordReset component when path is "/password-reset"', () => {
+            router.push({ path: '/password-reset' });
+
+            expect(wrapper.find('passwordreset-stub').exists()).toBeTruthy();
+        });
+    });
+
     describe('Main layout', () => {
         describe('path is "/user"', () => {
             beforeEach(() => {

--- a/src/api/authentication.js
+++ b/src/api/authentication.js
@@ -23,7 +23,7 @@ export const login = data => {
 
         store.dispatch('clearInvalidCredentials');
 
-        return data;
+        return response;
     });
 };
 

--- a/src/router.js
+++ b/src/router.js
@@ -10,6 +10,7 @@ import AuthenticationTokens from './views/AuthenticationTokens/AuthenticationTok
 import Navbar from './views/Navbar/Navbar.vue';
 import Sidebar from './views/Sidebar/Sidebar.vue';
 import PageNotFound from './views/PageNotFound/PageNotFound.vue';
+import PasswordReset from './views/PasswordReset/PasswordReset.vue';
 
 Vue.use(Router);
 
@@ -119,6 +120,13 @@ export default new Router({
                 default: UserManagement,
                 sidebar: Sidebar,
                 navbar: Navbar,
+            },
+        },
+        {
+            path: '/password-reset',
+            name: 'passwordReset',
+            component: {
+                PasswordReset,
             },
         },
         {

--- a/src/styles/components/_password-reset.scss
+++ b/src/styles/components/_password-reset.scss
@@ -1,0 +1,41 @@
+.password-reset-page {
+    .password-message {
+        padding: 0.75rem 0;
+
+        .message-header {
+            border-top-left-radius: 4px;
+            border-top-right-radius: 4px;
+        }
+
+        .message-body {
+            padding: 0.95em 1.5em;
+        }
+    }
+
+    .message-header {
+        justify-content: flex-start;
+
+        i.material-icons {
+            margin-right: 10px;
+        }
+    }
+
+    .box {
+        padding: 20px;
+    }
+
+    .message {
+        border-radius: 4px;
+    }
+
+    .button {
+        font-weight: bold;
+        height: 42px;
+        margin-top: 20px;
+    }
+
+    .button.save,
+    input {
+        border-radius: 4px;
+    }
+}

--- a/src/styles/main.scss
+++ b/src/styles/main.scss
@@ -32,6 +32,7 @@
 @import './components/edit-layout-modal';
 @import './components/navbar';
 @import './components/page-not-found';
+@import './components/password-reset';
 @import './components/phase-update-modal';
 @import './components/radial-progress';
 @import './components/sidebar';

--- a/src/views/PasswordReset/PasswordReset.vue
+++ b/src/views/PasswordReset/PasswordReset.vue
@@ -1,0 +1,208 @@
+<template>
+    <div class="password-reset-page hero is-dark is-fullheight">
+        <div class="hero-body">
+            <div class="container">
+                <div class="columns">
+                    <div class="column is-4 is-offset-4 password-message">
+                        <article class="message is-danger">
+                            <div class="message-header">
+                                <i class="material-icons">error</i>
+                                <span>
+                                    Password Update Required
+                                </span>
+                            </div>
+                            <div class="message-body">
+                                Your password needs to be updated immediately.
+                            </div>
+                        </article>
+                    </div>
+                </div>
+                <div class="columns">
+                    <div class="column is-4 is-offset-4 box">
+                        <transition name="fade">
+                            <article
+                                class="message error is-danger"
+                                v-if="
+                                    showError &&
+                                        (errors.passwordLength ||
+                                            errors.passwordMismatch)
+                                "
+                            >
+                                <div class="message-header">
+                                    <i class="material-icons">error</i>
+                                    <p>
+                                        <span v-if="errors.passwordLength">
+                                            Passwords must contain at least 12
+                                            characters.
+                                        </span>
+                                        <span v-if="errors.passwordMismatch">
+                                            The passwords you entered do not
+                                            match.
+                                        </span>
+                                    </p>
+                                </div>
+                            </article>
+                        </transition>
+                        <p class="title has-text-weight-bold is-4">
+                            Reset Password
+                        </p>
+                        <form>
+                            <div class="field">
+                                <label class="label">New Password</label>
+                                <div class="control has-icons-right">
+                                    <input
+                                        class="input password"
+                                        :class="{
+                                            'is-danger': errors.passwordLength,
+                                            'is-success': validPassword,
+                                        }"
+                                        type="password"
+                                        placeholder="New Password"
+                                        v-model="password"
+                                        ref="passwordInput"
+                                        @blur="validatePassword()"
+                                    />
+                                    <span
+                                        class="icon is-small is-right has-text-danger"
+                                        v-if="errors.passwordLength"
+                                    >
+                                        <i class="material-icons">error</i>
+                                    </span>
+                                    <span
+                                        class="icon is-small is-right has-text-success"
+                                        v-if="validPassword"
+                                    >
+                                        <i class="fas fa-check"></i>
+                                    </span>
+                                </div>
+                            </div>
+                            <div class="field">
+                                <label class="label">Confirm Password</label>
+                                <div class="control has-icons-right">
+                                    <input
+                                        class="input confirmation"
+                                        :class="{
+                                            'is-danger':
+                                                errors.passwordMismatch,
+                                            'is-success': validConfirmPassword,
+                                        }"
+                                        type="password"
+                                        placeholder="Confirm Password"
+                                        v-model="confirmPassword"
+                                        ref="confirmPassword"
+                                        @blur="validateConfirmPassword()"
+                                    />
+                                    <span
+                                        class="icon is-small is-right has-text-danger"
+                                        v-if="errors.passwordMismatch"
+                                    >
+                                        <i class="material-icons">error</i>
+                                    </span>
+                                    <span
+                                        class="icon is-small is-right has-text-success"
+                                        v-if="validConfirmPassword"
+                                    >
+                                        <i class="fas fa-check"></i>
+                                    </span>
+                                </div>
+                            </div>
+                            <a
+                                class="button save is-primary is-fullwidth"
+                                :class="{ 'is-loading': isLoading }"
+                                :disabled="isLoading"
+                                @click="savePassword()"
+                                type="button"
+                            >
+                                Update Password
+                            </a>
+                        </form>
+                    </div>
+                </div>
+            </div>
+        </div>
+    </div>
+</template>
+
+<script>
+import { mapActions } from 'vuex';
+import { updatePassword } from '@api/users.js';
+
+export default {
+    data() {
+        return {
+            confirmPassword: '',
+            errors: {},
+            isLoading: false,
+            password: '',
+            showError: false,
+            validConfirmPassword: false,
+            validPassword: false,
+        };
+    },
+    methods: {
+        ...mapActions(['clearForcePasswordChange']),
+        focusPasswordInput() {
+            this.$refs.passwordInput.focus();
+        },
+        resetErrors() {
+            this.errors = {};
+        },
+        savePassword() {
+            this.isLoading = true;
+            const password = this.password;
+            const confirmPassword = this.confirmPassword;
+            this.resetErrors();
+
+            if (!password || password.length < 5) {
+                this.errors.passwordLength = true;
+                this.isLoading = false;
+                this.showError = true;
+                return;
+            }
+
+            if (!confirmPassword || password !== confirmPassword) {
+                this.errors.passwordMismatch = true;
+                this.isLoading = false;
+                this.showError = true;
+                return;
+            } else {
+                updatePassword(password).then(() => {
+                    this.$router.push({ name: 'signIn' });
+                    this.isLoading = false;
+                });
+            }
+        },
+        validateConfirmPassword() {
+            this.validConfirmPassword = false;
+            const confirmPassword = this.confirmPassword;
+
+            if (!confirmPassword && !this.password) {
+                this.errors.passwordMismatch = false;
+            } else if (confirmPassword && confirmPassword === this.password) {
+                this.validConfirmPassword = true;
+                this.errors.passwordMismatch = false;
+            } else {
+                this.errors.passwordMismatch = true;
+            }
+        },
+        validatePassword() {
+            this.resetErrors();
+            this.showError = false;
+            this.validPassword = false;
+            const password = this.password;
+
+            if (password && password.length >= 12) {
+                this.validPassword = true;
+            }
+
+            if (this.confirmPassword) {
+                this.validateConfirmPassword();
+            }
+        },
+    },
+    mounted() {
+        this.focusPasswordInput();
+        this.clearForcePasswordChange();
+    },
+};
+</script>

--- a/src/views/PasswordReset/__tests__/PasswordReset.test.js
+++ b/src/views/PasswordReset/__tests__/PasswordReset.test.js
@@ -1,0 +1,70 @@
+import PasswordReset from '../PasswordReset.vue';
+import Vuex from 'vuex';
+import { createLocalVue, shallowMount } from '@vue/test-utils';
+
+const localVue = createLocalVue();
+localVue.use(Vuex);
+
+jest.mock('@api/request.js');
+
+describe('PasswordReset.vue', () => {
+    let actions;
+    let mocks;
+    let store;
+    let wrapper;
+
+    beforeEach(() => {
+        actions = {
+            clearForcePasswordChange: jest.fn(),
+        };
+        mocks = { $router: [] };
+        store = new Vuex.Store({ actions });
+        wrapper = shallowMount(PasswordReset, { localVue, mocks, store });
+    });
+
+    // Helper function
+    const savePassword = (pwd = '') => {
+        wrapper.find('input.password').setValue(pwd);
+        wrapper.find('input.confirmation').setValue(pwd);
+        wrapper.find('.button.save').trigger('click');
+    };
+
+    test('should render correctly on initial render', () => {
+        expect(wrapper.html()).toMatchSnapshot();
+    });
+
+    test('should call the savePassword method when a valid password is entered', () => {
+        const spy = jest.spyOn(wrapper.vm, 'savePassword');
+
+        savePassword('abcdefg');
+
+        expect(spy).toHaveBeenCalled();
+    });
+
+    test('should not display warning when a valid password is entered', () => {
+        savePassword('abcdefg');
+
+        expect(wrapper.find('.message.error').exists()).toEqual(false);
+    });
+
+    test('should display password mismatch warning when password does not match confirmation', () => {
+        wrapper.find('input.password').setValue('abcdefg');
+        wrapper.find('input.confirmation').setValue();
+        wrapper.find('.button.save').trigger('click');
+
+        expect(wrapper.html()).toContain('The passwords you entered do not');
+    });
+
+    test('should display password length warning when password is too short', () => {
+        savePassword();
+
+        expect(wrapper.html()).toContain('Passwords must contain at least');
+    });
+
+    test('should remove warning after a valid password is submitted', () => {
+        savePassword();
+        savePassword('abcdefg');
+
+        expect(wrapper.find('.message.error').exists()).toEqual(false);
+    });
+});

--- a/src/views/PasswordReset/__tests__/__snapshots__/PasswordReset.test.js.snap
+++ b/src/views/PasswordReset/__tests__/__snapshots__/PasswordReset.test.js.snap
@@ -1,0 +1,46 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`PasswordReset.vue should render correctly on initial render 1`] = `
+<div class="password-reset-page hero is-dark is-fullheight">
+  <div class="hero-body">
+    <div class="container">
+      <div class="columns">
+        <div class="column is-4 is-offset-4 password-message">
+          <article class="message is-danger">
+            <div class="message-header"><i class="material-icons">error</i> <span>
+                                Password Update Required
+                            </span></div>
+            <div class="message-body">
+              Your password needs to be updated immediately.
+            </div>
+          </article>
+        </div>
+      </div>
+      <div class="columns">
+        <div class="column is-4 is-offset-4 box">
+          <!---->
+          <p class="title has-text-weight-bold is-4">
+            Reset Password
+          </p>
+          <form>
+            <div class="field"><label class="label">New Password</label>
+              <div class="control has-icons-right"><input type="password" placeholder="New Password" class="input password">
+                <!---->
+                <!---->
+              </div>
+            </div>
+            <div class="field"><label class="label">Confirm Password</label>
+              <div class="control has-icons-right"><input type="password" placeholder="Confirm Password" class="input confirmation">
+                <!---->
+                <!---->
+              </div>
+            </div> <a type="button" class="button save is-primary is-fullwidth">
+              Update Password
+            </a>
+          </form>
+        </div>
+      </div>
+    </div>
+  </div>
+</div>
+`;

--- a/src/views/SignIn/SignIn.vue
+++ b/src/views/SignIn/SignIn.vue
@@ -165,7 +165,6 @@ import {
 } from '@src/config.js';
 import { getApiVersion } from '@api/conchApiVersion.js';
 import { mapActions, mapGetters, mapState } from 'vuex';
-import { getCurrentUser } from '@api/users.js';
 import { login } from '@api/authentication.js';
 import { loadAllWorkspaces } from '@api/workspaces.js';
 
@@ -189,7 +188,6 @@ export default {
     },
     methods: {
         ...mapActions([
-            'setCurrentUser',
             'setCurrentWorkspace',
             'setForcePasswordChange',
             'setWorkspaces',
@@ -220,39 +218,38 @@ export default {
                 };
 
                 login(data)
-                    .then(() => {
-                        getCurrentUser().then(response => {
-                            const currentUser = response.data;
-                            this.setCurrentUser(currentUser);
-
-                            if (currentUser.force_password_change) {
-                                this.setForcePasswordChange();
-                                this.$router.push({ name: 'user' });
-                            } else {
-                                if (isEmpty(this.workspaces)) {
-                                    this.initWorkspaceData().then(() => {
-                                        this.$router.push({
-                                            name: 'status',
-                                            params: {
-                                                currentWorkspace: this
-                                                    .currentWorkspaceId,
-                                            },
-                                        });
-                                    });
-                                } else {
-                                    this.setCurrentWorkspace(
-                                        this.loadCurrentWorkspace()
-                                    );
+                    .then(response => {
+                        if (
+                            response.headers &&
+                            response.headers.location &&
+                            response.headers.location === '/user/me/password'
+                        ) {
+                            this.setForcePasswordChange();
+                            this.$router.push({ name: 'passwordReset' });
+                        } else {
+                            if (isEmpty(this.workspaces)) {
+                                this.initWorkspaceData().then(() => {
                                     this.$router.push({
                                         name: 'status',
                                         params: {
-                                            currentWorkspace: this.$store
-                                                .getters.currentWorkspaceId,
+                                            currentWorkspace: this
+                                                .currentWorkspaceId,
                                         },
                                     });
-                                }
+                                });
+                            } else {
+                                this.setCurrentWorkspace(
+                                    this.loadCurrentWorkspace()
+                                );
+                                this.$router.push({
+                                    name: 'status',
+                                    params: {
+                                        currentWorkspace: this.$store.getters
+                                            .currentWorkspaceId,
+                                    },
+                                });
                             }
-                        });
+                        }
                     })
                     .catch(() => {
                         this.isLoading = false;

--- a/src/views/SignIn/__tests__/SignIn.test.js
+++ b/src/views/SignIn/__tests__/SignIn.test.js
@@ -64,32 +64,6 @@ describe('SignIn.vue', () => {
         expect(spy).toHaveBeenCalled();
     });
 
-    test('should call setForcePasswordChange method when force_password_change is true', async () => {
-        jest.spyOn(users, 'getCurrentUser').mockReturnValueOnce(
-            Promise.resolve({
-                data: {
-                    name: 'Valid User',
-                    email: 'validuser@joyent.com',
-                    password: 'abcdefg',
-                    force_password_change: true,
-                },
-            })
-        );
-
-        wrapper.setData({
-            emailAddress: 'validuser@joyent.com',
-            password: 'goodPassword',
-        });
-        wrapper.find('.button-sign-in').trigger('click');
-
-        await new Promise(resolve =>
-            setTimeout(() => {
-                expect(actions.setForcePasswordChange).toHaveBeenCalled();
-                resolve();
-            }, 100)
-        );
-    });
-
     test('should call the login method', () => {
         const spy = jest.spyOn(authentication, 'login');
 

--- a/src/views/UserProfile/AccountSettingsTab.vue
+++ b/src/views/UserProfile/AccountSettingsTab.vue
@@ -241,5 +241,8 @@ export default {
             }
         },
     },
+    mounted() {
+        this.$refs.passwordInput.focus();
+    },
 };
 </script>

--- a/src/views/UserProfile/UserProfile.vue
+++ b/src/views/UserProfile/UserProfile.vue
@@ -28,34 +28,6 @@
         </div>
         <AccountSettingsTab v-if="activeTab === 'settings'" />
         <AuthenticationTokensTab v-else-if="activeTab === 'tokens'" />
-        <div class="modal is-active" v-if="showModal">
-            <div class="modal-background" @click="closeModal()"></div>
-            <div class="modal-card">
-                <section class="modal-card-body">
-                    <article class="message is-danger is-medium">
-                        <div class="message-header">
-                            <p>Password Update Required</p>
-                            <button
-                                class="delete is-medium"
-                                aria-label="delete"
-                                @click="closeModal()"
-                            ></button>
-                        </div>
-                        <div class="message-body">
-                            <p>
-                                Your password needs to be updated immediately.
-                            </p>
-                            <a
-                                class="button is-danger update-password"
-                                @click="closeModal()"
-                            >
-                                Update Password
-                            </a>
-                        </div>
-                    </article>
-                </section>
-            </div>
-        </div>
     </div>
 </template>
 
@@ -63,7 +35,6 @@
 import AccountSettingsTab from './AccountSettingsTab.vue';
 import AuthenticationTokensTab from './AuthenticationTokensTab.vue';
 import PageHeader from '@src/views/components/PageHeader.vue';
-import { mapActions, mapState } from 'vuex';
 
 export default {
     components: {
@@ -74,24 +45,7 @@ export default {
     data() {
         return {
             activeTab: 'settings',
-            showModal: false,
         };
-    },
-    methods: {
-        ...mapActions(['clearForcePasswordChange']),
-        closeModal() {
-            this.showModal = false;
-            this.clearForcePasswordChange();
-            this.$refs.passwordInput.focus();
-        },
-    },
-    computed: {
-        ...mapState(['forcePasswordChange']),
-    },
-    mounted() {
-        if (this.forcePasswordChange) {
-            this.showModal = true;
-        }
     },
 };
 </script>

--- a/src/views/UserProfile/__tests__/UserProfile.test.js
+++ b/src/views/UserProfile/__tests__/UserProfile.test.js
@@ -38,48 +38,4 @@ describe('UserProfile.vue', () => {
             wrapper.find('authenticationtokenstab-stub').exists()
         ).toBeTruthy();
     });
-
-    describe('Password Reset Modal', () => {
-        let actions;
-
-        beforeEach(() => {
-            actions = { clearForcePasswordChange: jest.fn() };
-            methods = {
-                closeModal: () => {
-                    wrapper.vm.$data.showModal = false;
-                },
-            };
-            mocks = { $router: [] };
-            state = { forcePasswordChange: true };
-            store = new Vuex.Store({ actions, state });
-            wrapper = shallowMount(UserProfile, {
-                localVue,
-                methods,
-                mocks,
-                store,
-            });
-        });
-
-        test('should display the forcePasswordChange modal when forcePasswordChange is true', () => {
-            expect(wrapper.find('.modal').exists()).toBeTruthy();
-        });
-
-        test('should close modal when modal background is clicked', () => {
-            wrapper.find('.modal-background').trigger('click');
-
-            expect(wrapper.find('.modal').exists()).toBeFalsy();
-        });
-
-        test('should close modal when close (x) button is clicked', () => {
-            wrapper.find('button.delete').trigger('click');
-
-            expect(wrapper.find('.modal').exists()).toBeFalsy();
-        });
-
-        test('should close modal when the Update Password button is clicked', () => {
-            wrapper.find('.update-password').trigger('click');
-
-            expect(wrapper.find('.modal').exists()).toBeFalsy();
-        });
-    });
 });


### PR DESCRIPTION
These changes add a new PasswordReset component. Previous functionality had the user immediately directed to the User Profile page to reset their password, with a "Reset Password" modal providing some context and instruction. New functionality now has the user redirected to a separate Reset Password page that doesn't require any API calls to populate anything.

These changes also move from using `GET /user/me` to check password reset status to using the location header returned in the login response.

Closes #139 