### PR TITLE
Ensure workspaceId is available for API requests

### DIFF
--- a/src/views/DataCenterBrowser/DataCenterBrowser.vue
+++ b/src/views/DataCenterBrowser/DataCenterBrowser.vue
@@ -113,6 +113,7 @@ export default {
     },
     data() {
         return {
+            currentWorkspaceId: '',
             foundDevices: [],
             hideDropdown: true,
             maxFoundDevices: 12,
@@ -203,7 +204,7 @@ export default {
         },
     },
     computed: {
-        ...mapGetters(['currentWorkspaceId', 'currentWorkspaceName']),
+        ...mapGetters(['currentWorkspaceName']),
         ...mapState(['activeRoomName']),
         activeRacks() {
             if (this.rackRooms.length) {
@@ -236,8 +237,15 @@ export default {
         },
     },
     created() {
-        this.setWorkspaceDevices();
-        this.setWorkspaceRacks();
+        if (
+            this.$route &&
+            this.$route.params &&
+            this.$route.params.currentWorkspace
+        ) {
+            this.currentWorkspaceId = this.$route.params.currentWorkspace;
+            this.setWorkspaceDevices();
+            this.setWorkspaceRacks();
+        }
     },
     mounted() {
         if (this.$route && this.$route.params) {
@@ -248,6 +256,8 @@ export default {
             }
 
             if (routeParams.currentWorkspace && routeParams.rackId) {
+                this.currentWorkspaceId = routeParams.currentWorkspace;
+
                 getRackById(
                     routeParams.currentWorkspace,
                     routeParams.rackId
@@ -257,10 +267,11 @@ export default {
             }
         }
 
-        EventBus.$on('changeWorkspace:datacenter', () => {
+        EventBus.$on('changeWorkspace:datacenter', workspaceId => {
+            this.currentWorkspaceId = workspaceId;
+            this.clearActiveData();
             this.setWorkspaceDevices();
             this.setWorkspaceRacks();
-            this.clearActiveData();
         });
     },
     destroyed() {

--- a/src/views/Navbar/Navbar.vue
+++ b/src/views/Navbar/Navbar.vue
@@ -105,7 +105,7 @@ export default {
                     name = 'datacenter';
                 }
 
-                EventBus.$emit('changeWorkspace:datacenter');
+                EventBus.$emit('changeWorkspace:datacenter', workspaceId);
             }
 
             this.$router.push({ name: name, params: params });


### PR DESCRIPTION
- Fixes a null workspaceId on page refresh
- Fixes a bug where the Datacenter rooms did not update on the Datacenter Browser when the workspace was changed

Closes #144.